### PR TITLE
Flush localStorage writes on visibilityState hidden

### DIFF
--- a/src/components/shared-data-view.tsx
+++ b/src/components/shared-data-view.tsx
@@ -22,7 +22,7 @@ export function SharedDataView({ items, league }: SharedDataViewProps) {
       DEFAULT_ADVANCED_SETTINGS,
       "poe-udt:trade-settings:v1",
       {
-        timeout: 300,
+        debounceDelay: 300,
       },
     );
 

--- a/src/components/usePersistentRowSelection.tsx
+++ b/src/components/usePersistentRowSelection.tsx
@@ -18,7 +18,7 @@ export function usePersistentRowSelection(storageKey: string) {
   const [selectedIds, setSelectedIds] = useLocalStorage<string[]>(
     [],
     storageKey,
-    { timeout: 300 },
+    { debounceDelay: 300 },
   );
 
   const rowSelection = React.useMemo(() => {

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -19,13 +19,11 @@ export function useLocalStorage<T>(
 ): [T, (value: T | ((val: T) => T)) => void] {
   const { debounceDelay } = options;
 
-  const initialValue = (
+  const [value, setValue] = React.useState<T>(() =>
     typeof initialState === "function"
       ? (initialState as () => T)()
-      : initialState
-  ) as T;
-
-  const [value, setValue] = React.useState<T>(() => initialValue);
+      : initialState,
+  );
   const valueRef = React.useRef<T>(value);
   React.useLayoutEffect(() => {
     valueRef.current = value;

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -17,6 +17,9 @@ export function useLocalStorage<T>(
     debounceDelay?: number;
   } = {},
 ): [T, (value: T | ((val: T) => T)) => void] {
+  if (!key) {
+    throw new Error("useLocalStorage: key must be a non-empty string");
+  }
   const { debounceDelay } = options;
 
   const [value, setValue] = React.useState<T>(() =>
@@ -54,7 +57,7 @@ export function useLocalStorage<T>(
     [key],
   );
 
-  // On mount, read from localStorage
+  // On mount and when key changes, read from localStorage
   React.useEffect(() => {
     if (typeof window === "undefined") return;
     const value = readFromStorage();

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -66,7 +66,6 @@ export function useLocalStorage<T>(
 
   // On mount and when key changes, read from localStorage
   React.useEffect(() => {
-    if (typeof window === "undefined") return;
     const value = readFromStorage();
     if (value === undefined) return;
     setValue(value);
@@ -85,8 +84,6 @@ export function useLocalStorage<T>(
 
   // On value change, write to localStorage (debounced if debounceDelay > 0)
   React.useEffect(() => {
-    if (typeof window === "undefined") return;
-
     if (debounceDelay) {
       clearDebounce();
       debounceRef.current = setTimeout(() => {
@@ -106,8 +103,6 @@ export function useLocalStorage<T>(
   // Not using pagehide, unload or beforeunload since their firing is non-deterministic
   // visibilitychange is supported in every modern browser
   React.useEffect(() => {
-    if (typeof window === "undefined") return;
-
     const handleFlush = () => {
       if (document.visibilityState !== "hidden") return;
       clearDebounce();

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -63,14 +63,16 @@ export function useLocalStorage<T>(
     if (value === undefined) return;
     setValue(value);
 
+    // Update the value ref asynchronously to avoid a race condition
+    // in case we unmount immediately after (e.g. Strict Mode)
+    valueRef.current = value;
+
+    // On unmount, write the final value to localStorage
     return () => {
       // Cancel any existing debounce/flush
       if (debounceRef.current) clearTimeout(debounceRef.current);
 
-      // Defer the final flush so a Strict Mode unmount->remount can cancel it.
-      debounceRef.current = setTimeout(() => {
-        writeToStorage(valueRef.current);
-      }, 0);
+      writeToStorage(valueRef.current);
     };
   }, [readFromStorage, writeToStorage]);
 

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -25,7 +25,7 @@ export function useLocalStorage<T>(
       : initialState
   ) as T;
 
-  const [value, setValue] = React.useState<T>(initialValue);
+  const [value, setValue] = React.useState<T>(() => initialValue);
   const valueRef = React.useRef<T>(value);
   React.useLayoutEffect(() => {
     valueRef.current = value;

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -76,7 +76,7 @@ export function useLocalStorage<T>(
     };
   }, [readFromStorage, writeToStorage]);
 
-  // On value change, write to localStorage (debounced if timeout > 0)
+  // On value change, write to localStorage (debounced if debounceDelay > 0)
   React.useEffect(() => {
     if (typeof window === "undefined") return;
 

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -23,7 +23,7 @@ export function useLocalStorage<T>(
 
   const [value, setValue] = React.useState<T>(initialState);
 
-  const throttle = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debounce = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Track latest value for unmount/pagehide/hidden flushes without resubscribing listeners
   const valueRef = React.useRef(value);
@@ -61,14 +61,14 @@ export function useLocalStorage<T>(
     if (typeof window === "undefined") return;
 
     if (timeout) {
-      if (throttle.current) clearTimeout(throttle.current);
-      throttle.current = setTimeout(() => flush(value), timeout);
+      if (debounce.current) clearTimeout(debounce.current);
+      debounce.current = setTimeout(() => flush(value), timeout);
     } else {
       flush(value);
     }
 
     return () => {
-      if (throttle.current) clearTimeout(throttle.current);
+      if (debounce.current) clearTimeout(debounce.current);
     };
   }, [key, timeout, value, flush]);
 
@@ -79,9 +79,9 @@ export function useLocalStorage<T>(
 
     const handleFlush = () => {
       if (document.visibilityState !== "hidden") return;
-      if (throttle.current) {
-        clearTimeout(throttle.current);
-        throttle.current = null;
+      if (debounce.current) {
+        clearTimeout(debounce.current);
+        debounce.current = null;
       }
       flush(value);
     };
@@ -97,9 +97,9 @@ export function useLocalStorage<T>(
   React.useEffect(() => {
     return () => {
       if (typeof window === "undefined") return;
-      if (throttle.current) {
-        clearTimeout(throttle.current);
-        throttle.current = null;
+      if (debounce.current) {
+        clearTimeout(debounce.current);
+        debounce.current = null;
       }
       flush(valueRef.current);
     };

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -57,6 +57,13 @@ export function useLocalStorage<T>(
     [key],
   );
 
+  const clearDebounce = React.useCallback(() => {
+    if (debounceRef.current != null) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+  }, []);
+
   // On mount and when key changes, read from localStorage
   React.useEffect(() => {
     if (typeof window === "undefined") return;
@@ -71,18 +78,17 @@ export function useLocalStorage<T>(
     // On unmount, write the final value to localStorage
     return () => {
       // Cancel any existing debounce/flush
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-
+      clearDebounce();
       writeToStorage(valueRef.current);
     };
-  }, [readFromStorage, writeToStorage]);
+  }, [readFromStorage, writeToStorage, clearDebounce]);
 
   // On value change, write to localStorage (debounced if debounceDelay > 0)
   React.useEffect(() => {
     if (typeof window === "undefined") return;
 
     if (debounceDelay) {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      clearDebounce();
       debounceRef.current = setTimeout(() => {
         writeToStorage(valueRef.current);
       }, debounceDelay);
@@ -91,9 +97,9 @@ export function useLocalStorage<T>(
     }
 
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      clearDebounce();
     };
-  }, [value, writeToStorage, debounceDelay]);
+  }, [value, debounceDelay, writeToStorage, clearDebounce]);
 
   // On every visibilityState === hidden, flush defensively
   // to avoid dropped writes
@@ -104,7 +110,7 @@ export function useLocalStorage<T>(
 
     const handleFlush = () => {
       if (document.visibilityState !== "hidden") return;
-      if (debounceRef.current) clearTimeout(debounceRef.current);
+      clearDebounce();
       writeToStorage(valueRef.current);
     };
 
@@ -113,7 +119,7 @@ export function useLocalStorage<T>(
     return () => {
       document.removeEventListener("visibilitychange", handleFlush);
     };
-  }, [writeToStorage]);
+  }, [writeToStorage, clearDebounce]);
 
   return [value, setValue];
 }

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -66,13 +66,13 @@ export function useLocalStorage<T>(
 
   // On mount and when key changes, read from localStorage
   React.useEffect(() => {
-    const value = readFromStorage();
-    if (value === undefined) return;
-    setValue(value);
+    const storedValue = readFromStorage();
+    if (storedValue === undefined) return;
+    setValue(storedValue);
 
-    // Update the value ref asynchronously to avoid a race condition
-    // in case we unmount immediately after (e.g. Strict Mode)
-    valueRef.current = value;
+    // Update valueRef here so cleanup flushes the freshly loaded value
+    // even if we unmount before the next render cycle
+    valueRef.current = storedValue;
 
     // On unmount, write the final value to localStorage
     return () => {

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -25,6 +25,12 @@ export function useLocalStorage<T>(
 
   const throttle = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Track latest value for unmount/pagehide/hidden flushes without resubscribing listeners
+  const valueRef = React.useRef(value);
+  React.useLayoutEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
   // On mount, read from localStorage
   React.useEffect(() => {
     if (typeof window === "undefined") return;
@@ -66,7 +72,7 @@ export function useLocalStorage<T>(
     };
   }, [key, timeout, value, flush]);
 
-  // Flush defensively on every visibilityState === hidden
+  // On every visibilityState === hidden, flush defensively
   // to avoid dropped writes
   React.useEffect(() => {
     if (typeof window === "undefined") return;
@@ -86,6 +92,18 @@ export function useLocalStorage<T>(
       document.removeEventListener("visibilitychange", handleFlush);
     };
   }, [flush, value]);
+
+  // On unmount, flush any pending write to avoid drops (e.g., route changes)
+  React.useEffect(() => {
+    return () => {
+      if (typeof window === "undefined") return;
+      if (throttle.current) {
+        clearTimeout(throttle.current);
+        throttle.current = null;
+      }
+      flush(valueRef.current);
+    };
+  }, [flush]);
 
   return [value, setValue];
 }

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -94,6 +94,8 @@ export function useLocalStorage<T>(
 
   // On every visibilityState === hidden, flush defensively
   // to avoid dropped writes
+  // Not using pagehide, unload or beforeunload since their firing is non-deterministic
+  // visibilitychange is supported in every modern browser
   React.useEffect(() => {
     if (typeof window === "undefined") return;
 

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -1,4 +1,4 @@
-// https://gist.github.com/lukemcdonald/021d5584c058dfd570d59586daaefe59
+// Based on https://gist.github.com/lukemcdonald/021d5584c058dfd570d59586daaefe59
 
 import React from "react";
 
@@ -7,45 +7,45 @@ import React from "react";
  *
  * @param initialState The initial value to use
  * @param key The local storage key to use
- * @param options Optional. Currently allows a timeout (in milliseconds) to debouce the setting localStorage if needed.
+ * @param options Optional. Currently allows a debounceDelay (in milliseconds) to debounce the setting localStorage if needed.
  * @returns The current value of the local storage item state, and a function to set it
  */
 export function useLocalStorage<T>(
-  initialState: T,
+  initialState: T | (() => T),
   key: string,
   options: {
-    timeout?: number;
-  } = {
-    timeout: 0,
-  },
+    debounceDelay?: number;
+  } = {},
 ): [T, (value: T | ((val: T) => T)) => void] {
-  const { timeout } = options;
+  const { debounceDelay } = options;
 
-  const [value, setValue] = React.useState<T>(initialState);
+  const initialValue = (
+    typeof initialState === "function"
+      ? (initialState as () => T)()
+      : initialState
+  ) as T;
 
-  const debounce = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Track latest value for unmount/pagehide/hidden flushes without resubscribing listeners
-  const valueRef = React.useRef(value);
+  const [value, setValue] = React.useState<T>(initialValue);
+  const valueRef = React.useRef<T>(value);
   React.useLayoutEffect(() => {
     valueRef.current = value;
   }, [value]);
 
-  // On mount, read from localStorage
-  React.useEffect(() => {
-    if (typeof window === "undefined") return;
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const readFromStorage = React.useCallback((): T | undefined => {
     try {
       const item = window.localStorage.getItem(key);
       if (item !== null) {
-        setValue(JSON.parse(item));
+        const parsed = JSON.parse(item);
+        return parsed;
       }
     } catch (err) {
       console.error(`Error reading localStorage key "${key}":`, err);
     }
   }, [key]);
 
-  // Helper to write immediately
-  const flush = React.useCallback(
+  const writeToStorage = React.useCallback(
     (val: T) => {
       try {
         window.localStorage.setItem(key, JSON.stringify(val));
@@ -56,21 +56,41 @@ export function useLocalStorage<T>(
     [key],
   );
 
+  // On mount, read from localStorage
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const value = readFromStorage();
+    if (value === undefined) return;
+    setValue(value);
+
+    return () => {
+      // Cancel any existing debounce/flush
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+
+      // Defer the final flush so a Strict Mode unmount->remount can cancel it.
+      debounceRef.current = setTimeout(() => {
+        writeToStorage(valueRef.current);
+      }, 0);
+    };
+  }, [readFromStorage, writeToStorage]);
+
   // On value change, write to localStorage (debounced if timeout > 0)
   React.useEffect(() => {
     if (typeof window === "undefined") return;
 
-    if (timeout) {
-      if (debounce.current) clearTimeout(debounce.current);
-      debounce.current = setTimeout(() => flush(value), timeout);
+    if (debounceDelay) {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        writeToStorage(valueRef.current);
+      }, debounceDelay);
     } else {
-      flush(value);
+      writeToStorage(value);
     }
 
     return () => {
-      if (debounce.current) clearTimeout(debounce.current);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [key, timeout, value, flush]);
+  }, [value, writeToStorage, debounceDelay]);
 
   // On every visibilityState === hidden, flush defensively
   // to avoid dropped writes
@@ -79,11 +99,8 @@ export function useLocalStorage<T>(
 
     const handleFlush = () => {
       if (document.visibilityState !== "hidden") return;
-      if (debounce.current) {
-        clearTimeout(debounce.current);
-        debounce.current = null;
-      }
-      flush(value);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      writeToStorage(valueRef.current);
     };
 
     document.addEventListener("visibilitychange", handleFlush);
@@ -91,19 +108,7 @@ export function useLocalStorage<T>(
     return () => {
       document.removeEventListener("visibilitychange", handleFlush);
     };
-  }, [flush, value]);
-
-  // On unmount, flush any pending write to avoid drops (e.g., route changes)
-  React.useEffect(() => {
-    return () => {
-      if (typeof window === "undefined") return;
-      if (debounce.current) {
-        clearTimeout(debounce.current);
-        debounce.current = null;
-      }
-      flush(valueRef.current);
-    };
-  }, [flush]);
+  }, [writeToStorage]);
 
   return [value, setValue];
 }

--- a/src/lib/use-local-storage.tsx
+++ b/src/lib/use-local-storage.tsx
@@ -10,7 +10,6 @@ import React from "react";
  * @param options Optional. Currently allows a timeout (in milliseconds) to debouce the setting localStorage if needed.
  * @returns The current value of the local storage item state, and a function to set it
  */
-
 export function useLocalStorage<T>(
   initialState: T,
   key: string,
@@ -39,26 +38,54 @@ export function useLocalStorage<T>(
     }
   }, [key]);
 
+  // Helper to write immediately
+  const flush = React.useCallback(
+    (val: T) => {
+      try {
+        window.localStorage.setItem(key, JSON.stringify(val));
+      } catch (err) {
+        console.error(`Error writing localStorage key "${key}":`, err);
+      }
+    },
+    [key],
+  );
+
   // On value change, write to localStorage (debounced if timeout > 0)
   React.useEffect(() => {
     if (typeof window === "undefined") return;
-    try {
-      if (timeout) {
-        if (throttle.current) clearTimeout(throttle.current);
-        throttle.current = setTimeout(() => {
-          window.localStorage.setItem(key, JSON.stringify(value));
-        }, timeout);
-      } else {
-        window.localStorage.setItem(key, JSON.stringify(value));
-      }
-    } catch (err) {
-      console.error(`Error writing localStorage key "${key}":`, err);
+
+    if (timeout) {
+      if (throttle.current) clearTimeout(throttle.current);
+      throttle.current = setTimeout(() => flush(value), timeout);
+    } else {
+      flush(value);
     }
 
     return () => {
       if (throttle.current) clearTimeout(throttle.current);
     };
-  }, [key, timeout, value]);
+  }, [key, timeout, value, flush]);
+
+  // Flush defensively on every visibilityState === hidden
+  // to avoid dropped writes
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleFlush = () => {
+      if (document.visibilityState !== "hidden") return;
+      if (throttle.current) {
+        clearTimeout(throttle.current);
+        throttle.current = null;
+      }
+      flush(value);
+    };
+
+    document.addEventListener("visibilitychange", handleFlush);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleFlush);
+    };
+  }, [flush, value]);
 
   return [value, setValue];
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures pending changes are saved when switching tabs, hiding the page, or closing to prevent lost preferences.

* **Performance**
  * Reduces unnecessary storage writes via configurable debouncing; immediate saves remain when no delay is set.

* **Stability**
  * More reliable mount/unmount behavior, key validation, and safer storage operations with robust error handling.

* **Notes**
  * Debounce option renamed to debounceDelay; initial state may be provided lazily (function form).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->