### PR TITLE
Always use client locale for absolute time

### DIFF
--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -30,10 +30,7 @@ export const formatRelativeTime = (
 };
 
 export const formatAbsoluteTime = (timestamp: Date) => {
-  const clientLocale = navigator.language || "en-US";
-  const localeForFormatting = clientLocale.startsWith("en")
-    ? clientLocale
-    : `en-${clientLocale.split("-")[1] || "US"}`;
+  const localeForFormatting = navigator.language;
 
   return new Intl.DateTimeFormat(localeForFormatting, {
     year: "numeric",
@@ -42,7 +39,6 @@ export const formatAbsoluteTime = (timestamp: Date) => {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
-    hour12: false,
     timeZoneName: "short",
   }).format(timestamp);
 };

--- a/src/tests/e2e/tests/desktop/core-functionality.spec.ts
+++ b/src/tests/e2e/tests/desktop/core-functionality.spec.ts
@@ -247,9 +247,14 @@ test.describe("Last Updated Functionality", () => {
     expect(tooltip).toHaveText(/absolute time/i);
 
     const absoluteTime = tooltip.locator("time").first();
-    await expect(absoluteTime).toHaveText(
-      /[\w ,]+ \d{1,2}[:]\d{2}[:]\d{2} [A-Z]{2,4}(?:[+-]?\d{1,2})?/i,
-    );
+    const displayedText = await absoluteTime.innerText();
+
+    // Should render something non-empty and time-like
+    expect(displayedText.trim().length).toBeGreaterThan(0);
+    expect(displayedText).toMatch(/\d/); // contains digits
+    expect(displayedText).not.toMatch(/Invalid Date/);
+    expect(displayedText).not.toMatch(/NaN/);
+
     await poePage.verifyDateTimeAttribute(absoluteTime);
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined time display to respect browser locale settings for formatting and hour format (12/24-hour) determination.

* **Tests**
  * Updated time validation logic to be more robust, confirming valid time content rather than strict format matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->