### PR TITLE
Change revalidation time to 30 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Path of Exile tool for calculating unique item disenchanting efficiency in Kings
 
 ## Features
 
-- Real-time price data from poe.ninja API (refreshed every 15 minutes)
+- Real-time price data from poe.ninja API (refreshed every 30 minutes)
 - Dust value calculations based on item type and level
 - Filtering (name, price range)
 - Sorting (dust per chaos, dust value, price, name)

--- a/src/app/[league]/page.tsx
+++ b/src/app/[league]/page.tsx
@@ -11,7 +11,7 @@ import { getLeagueName, League, LEAGUE_SLUGS } from "@/lib/leagues";
 type Props = { params: Promise<{ league: League }> };
 
 export const dynamicParams = false;
-export const revalidate = 900; // 15 minutes
+export const revalidate = 1800; // 30 minutes
 
 export default async function LeaguePage({ params }: Props) {
   const { league } = await params;

--- a/src/components/last-updated.tsx
+++ b/src/components/last-updated.tsx
@@ -73,7 +73,7 @@ export default function LastUpdated({
 
       setRelativeTime(relative);
       setAbsoluteTime(absolute);
-      setIsStale(diffInMinutes >= 15);
+      setIsStale(diffInMinutes >= 30);
       setIsRefreshing(false);
     };
 

--- a/src/lib/itemData/itemData.ts
+++ b/src/lib/itemData/itemData.ts
@@ -166,6 +166,6 @@ function calculateLowStockThreshold(items: Item[]) {
 export const getItems = async (league: League) => {
   return unstable_cache(async () => uncached__getItems(league), [league], {
     tags: [`items-${league}`],
-    revalidate: 900, // 15 minutes
+    revalidate: 1800, // 30 minutes
   })();
 };


### PR DESCRIPTION
free tier hurts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated data refresh intervals from 15 minutes to 30 minutes. Price information and cached data will now be refreshed at the longer interval across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->