### PR TITLE
Fix filter chips layout on lg breakpoint

### DIFF
--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -45,7 +45,9 @@ export function DataTableToolbar<TData extends Item>({
             />
           </div>
 
-          <FilterChips table={table} />
+          <div className="xl:col-span-auto col-span-2">
+            <FilterChips table={table} />
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
The filter chips should now be stacked horizontally on the lg breakpoint, just under name filter/tabbed filter, using all horizontal space. Other breakpoints should be unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted responsive layout for filter controls across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->