### PR TITLE
Fix slots text alignment in dust/chaos/slot column

### DIFF
--- a/src/components/columns.tsx
+++ b/src/components/columns.tsx
@@ -191,7 +191,7 @@ const DustPerChaosPerSlotCell: ColumnDef<Item>["cell"] =
           <span className="text-muted-foreground">/</span>
           <ChaosOrbIcon />
           <span className="text-muted-foreground">/</span>
-          <span className="min-w-9 text-left text-xs">
+          <span className="min-w-10 text-left text-xs">
             {slots} slot{slots !== 1 ? "s" : ""}
           </span>
         </span>


### PR DESCRIPTION
Now slightly bigger to accommodate longer text, resulting in perfect vertical alignment for all data rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted label width for improved visual alignment in the display table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->