### PR TITLE
Archive Phrecia 2.0 leagues

### DIFF
--- a/src/components/league-selector.tsx
+++ b/src/components/league-selector.tsx
@@ -4,7 +4,6 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
-import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -66,14 +65,7 @@ export function LeagueSelector({ currentLeague }: LeagueSelectorProps) {
             <SelectContent>
               {LEAGUE_SLUGS.map((slug) => (
                 <SelectItem key={slug} value={slug}>
-                  <div className="flex items-center gap-2">
-                    {LEAGUES[slug].name}
-                    {(slug === "phrecia2.0" || slug === "phrecia2.0hc") && (
-                      <Badge variant="blue" className="text-xs">
-                        New
-                      </Badge>
-                    )}
-                  </div>
+                  {LEAGUES[slug].name}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/lib/leagues.ts
+++ b/src/lib/leagues.ts
@@ -6,11 +6,6 @@ export const LEAGUES = {
     name: "Hardcore Keepers",
     apiName: "Hardcore Keepers",
   },
-  "phrecia2.0": { name: "Phrecia 2.0", apiName: "Phrecia 2.0" },
-  "phrecia2.0hc": {
-    name: "Hardcore Phrecia 2.0",
-    apiName: "Hardcore Phrecia 2.0",
-  },
 } as const;
 
 export const ARCHIVED_LEAGUES = {
@@ -21,6 +16,11 @@ export const ARCHIVED_LEAGUES = {
   "hardcore-mercenaries": {
     name: "Hardcore Mercenaries",
     apiName: "Hardcore Mercenaries",
+  },
+  "phrecia2.0": { name: "Phrecia 2.0", apiName: "Phrecia 2.0" },
+  "phrecia2.0hc": {
+    name: "Hardcore Phrecia 2.0",
+    apiName: "Hardcore Phrecia 2.0",
   },
 } as const;
 
@@ -38,8 +38,6 @@ export const DATE_PUBLISHED_LEAGUES: Record<League, Date> = {
   hardcore: new Date("2025-06-01"),
   keepers: new Date("2025-10-31"),
   "hardcore-keepers": new Date("2025-10-31"),
-  "phrecia2.0": new Date("2026-01-29"),
-  "phrecia2.0hc": new Date("2026-01-29"),
 };
 
 export function isValidLeague(slug: string): slug is League {


### PR DESCRIPTION
Move Phrecia 2.0 and Hardcore Phrecia 2.0 from active leagues to archived leagues. Remove the "New" badge from league selector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed "New" badges from the league selector interface to streamline the user interface and provide a cleaner visual presentation.

* **Chores**
  * Archived Phrecia 2.0 and Hardcore Phrecia 2.0 leagues, transitioning them from the active league list to archived status for improved league organization and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->