### PR TITLE
Add online in league trade status

### DIFF
--- a/src/components/advanced-settings-panel.tsx
+++ b/src/components/advanced-settings-panel.tsx
@@ -267,13 +267,13 @@ export function AdvancedSettingsPanel({
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="available">
-                    Instant Buyout & In-Person
+                    Instant Buyout & In Person
                   </SelectItem>
                   <SelectItem value="securable">Instant Buyout</SelectItem>
                   <SelectItem value="onlineleague">
-                    In-Person (Online In League)
+                    In Person (Online In League)
                   </SelectItem>
-                  <SelectItem value="online">In-Person (Online)</SelectItem>
+                  <SelectItem value="online">In Person (Online)</SelectItem>
                   <SelectItem value="any">Any (Possibly Offline)</SelectItem>
                 </SelectContent>
               </Select>

--- a/src/lib/online-status.ts
+++ b/src/lib/online-status.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
 export const OnlineStatusSchema = z.enum([
-  "available", // Instant Buyout and In-Person Trade
+  "available", // Instant Buyout and In Person Trade
   "securable", // Instant Buyout
-  "onlineleague", // In-Person (Online In League)
-  "online", // In-Person (Online)
+  "onlineleague", // In Person (Online In League)
+  "online", // In Person (Online)
   "any", // Any
 ]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Online Status options for improved clarity and flexibility. Updated "Instant Buyout" label for clearer intent. Added two new trading preference options: "In-Person (Online In League)" and "In-Person (Online)" to better accommodate different transaction types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->