### PR TITLE
Replace root route redirect with CDN-level redirect

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -42,13 +42,22 @@ const nextConfig: NextConfig = {
     PDT_APP_NAME: packageJson.name,
   },
   devIndicators: process.env.PLAYWRIGHT ? false : undefined, // Disable dev tools in Playwright for VRT
-  // Static redirects for archival leagues - handled at CDN/edge level
+  // Static redirects - handled at CDN/edge level
   async redirects() {
-    return ARCHIVED_LEAGUE_SLUGS.map((archivedLeague) => ({
-      source: `/${archivedLeague}`,
-      destination: `/${DEFAULT_LEAGUE}`,
-      permanent: true,
-    }));
+    return [
+      // Root redirect - temporary because DEFAULT_LEAGUE changes
+      {
+        source: "/",
+        destination: `/${DEFAULT_LEAGUE}`,
+        permanent: false,
+      },
+      // Archival leagues - permanent because these URLs will not come back
+      ...ARCHIVED_LEAGUE_SLUGS.map((archivedLeague) => ({
+        source: `/${archivedLeague}`,
+        destination: `/${DEFAULT_LEAGUE}`,
+        permanent: true,
+      })),
+    ];
   },
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,0 @@
-import { redirect } from "next/navigation";
-
-import { DEFAULT_LEAGUE } from "@/lib/leagues";
-
-export default function Home() {
-  // Redirect to default league
-  redirect(`/${DEFAULT_LEAGUE}`);
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated redirect configuration to handle root-level and archival league routes separately
  * Root-level redirect changed to temporary (non-permanent) behavior
  * Archival league redirects remain permanent

<!-- end of auto-generated comment: release notes by coderabbit.ai -->