### PR TITLE
Add Vercel Insights endpoint to robots disallow

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,8 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      // Crawlers hit below URL often, which is not needed
+      disallow: "/_vercel/insights/",
     },
     sitemap: `${BASE_URL}/sitemap.xml`,
   };


### PR DESCRIPTION
https://community.vercel.com/t/crawl-requests-from-google-to-vercel-insights-view/28898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine crawler directives to restrict access to internal analytics paths while preserving sitemap discovery and indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->