### PR TITLE
Handle edge case where listingCount is undefined

### DIFF
--- a/src/lib/prices/prices.ts
+++ b/src/lib/prices/prices.ts
@@ -30,7 +30,7 @@ const LineSchema = z.object({
   divineValue: z.number().optional(),
   baseType: z.string(),
   icon: z.url(),
-  listingCount: z.int(),
+  listingCount: z.int().optional().default(0),
   detailsId: z.string(),
   itemType: z.string(),
 });


### PR DESCRIPTION
```
[
  {
    "expected": "number",
    "code": "invalid_type",
    "path": [
      "lines",
      50,
      "listingCount"
    ],
    "message": "Invalid input: expected number, received undefined"
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing listing counts in incoming data, so records without this value now default to `0` instead of being rejected.
  * Downstream item processing and aggregation now continue smoothly when listing counts are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->