### PR TITLE
Archive Mirage league

### DIFF
--- a/src/lib/leagues.ts
+++ b/src/lib/leagues.ts
@@ -1,8 +1,6 @@
 export const LEAGUES = {
   standard: { name: "Standard", apiName: "Standard" },
   hardcore: { name: "Hardcore", apiName: "Hardcore" },
-  mirage: { name: "Mirage", apiName: "Mirage" },
-  "hardcore-mirage": { name: "Hardcore Mirage", apiName: "Hardcore Mirage" },
 } as const;
 
 export const ARCHIVED_LEAGUES = {
@@ -29,11 +27,13 @@ export const ARCHIVED_LEAGUES = {
     name: "Hardcore Ancestors",
     apiName: "Hardcore Ancestors",
   },
+  mirage: { name: "Mirage", apiName: "Mirage" },
+  "hardcore-mirage": { name: "Hardcore Mirage", apiName: "Hardcore Mirage" },
 } as const;
 
 export type League = keyof typeof LEAGUES;
 export const LEAGUE_SLUGS = Object.keys(LEAGUES) as League[];
-export const DEFAULT_LEAGUE: League = "mirage";
+export const DEFAULT_LEAGUE: League = "standard";
 
 export type ArchivedLeague = keyof typeof ARCHIVED_LEAGUES;
 export const ARCHIVED_LEAGUE_SLUGS = Object.keys(
@@ -43,8 +43,6 @@ export const ARCHIVED_LEAGUE_SLUGS = Object.keys(
 export const DATE_PUBLISHED_LEAGUES: Record<League, Date> = {
   standard: new Date("2025-06-01"),
   hardcore: new Date("2025-06-01"),
-  mirage: new Date("2026-03-06"),
-  "hardcore-mirage": new Date("2026-03-06"),
 };
 
 export function isValidLeague(slug: string): slug is League {

--- a/src/tests/e2e/tests/desktop/core-functionality.spec.ts
+++ b/src/tests/e2e/tests/desktop/core-functionality.spec.ts
@@ -87,12 +87,14 @@ test.describe("League Selector Functionality", () => {
     poePage,
     page,
   }) => {
-    const selectedLeague = "standard";
-    await poePage.selectLeague(selectedLeague);
-    await poePage.verifyLeagueSelected(selectedLeague);
+    // Get first which key isn't DEFAULT_LEAGUE
+    const leagueToSelect = LEAGUE_SLUGS.find((key) => key !== DEFAULT_LEAGUE)!;
+    expect(leagueToSelect).toBeDefined();
+    await poePage.selectLeague(leagueToSelect);
+    await poePage.verifyLeagueSelected(leagueToSelect);
     await page.reload();
     await poePage.waitForDataLoad();
-    await poePage.verifyLeagueSelected(selectedLeague);
+    await poePage.verifyLeagueSelected(leagueToSelect);
   });
 
   test("should support keyboard open/close in league selector", async ({


### PR DESCRIPTION
/schedule 2026-07-20T22:00:00Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the available league lineup by moving Mirage leagues to the archived leagues list.
  * Standard is now the default league.

* **Bug Fixes**
  * Improved league selection persistence checks across page reloads for non-default leagues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->