### PR TITLE
Add tests for clear marks button number

### DIFF
--- a/src/tests/e2e/poe-page.ts
+++ b/src/tests/e2e/poe-page.ts
@@ -239,6 +239,11 @@ export class PoEDisenchantPage {
     }
   }
 
+  async verifyClearMarksCount(count: number): Promise<void> {
+    const button = this.clearMarksButton;
+    await expect(button).toContainText(`(${count})`);
+  }
+
   // ---------------------------
   // Trade Links
   // ---------------------------

--- a/src/tests/e2e/tests/desktop/user-interactions.spec.ts
+++ b/src/tests/e2e/tests/desktop/user-interactions.spec.ts
@@ -68,6 +68,28 @@ test.describe("Row Selection & Marking", () => {
     await poePage.verifyItemSelected(item.name, false);
   });
 
+  test("should display the number of selected rows on the Clear Marks button", async ({
+    poePage,
+  }) => {
+    const [first, second, third] = await poePage.getTestItems(3);
+
+    await poePage.verifyClearMarksCount(0);
+    await expect(poePage.clearMarksButton).toBeDisabled();
+
+    await poePage.selectItems([first.name]);
+    await poePage.verifyClearMarksCount(1);
+
+    await poePage.selectItems([second.name, third.name]);
+    await poePage.verifyClearMarksCount(3);
+
+    await poePage.selectItem(second.name); // toggle off
+    await poePage.verifyClearMarksCount(2);
+
+    await poePage.clearAllSelections();
+    await poePage.verifyClearMarksCount(0);
+    await expect(poePage.clearMarksButton).toBeDisabled();
+  });
+
   test("should clear marks via keyboard", async ({ poePage }) => {
     const [item] = await poePage.getTestItems();
     await poePage.selectItem(item.name);

--- a/src/tests/e2e/tests/desktop/user-interactions.spec.ts
+++ b/src/tests/e2e/tests/desktop/user-interactions.spec.ts
@@ -71,7 +71,9 @@ test.describe("Row Selection & Marking", () => {
   test("should display the number of selected rows on the Clear Marks button", async ({
     poePage,
   }) => {
-    const [first, second, third] = await poePage.getTestItems(3);
+    const items = await poePage.getTestItems(3);
+    expect(items.length).toBeGreaterThanOrEqual(3);
+    const [first, second, third] = items;
 
     await poePage.verifyClearMarksCount(0);
     await expect(poePage.clearMarksButton).toBeDisabled();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage verifying that the Clear Marks button accurately reflects selected rows.
  * Confirmed the count updates when selections change, resets after clearing, and the button is disabled when no rows are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->