### PR TITLE
Make default min item level 84

### DIFF
--- a/src/components/advanced-settings-context.tsx
+++ b/src/components/advanced-settings-context.tsx
@@ -4,8 +4,10 @@ import type { AdvancedSettings } from "@/lib/advanced-settings";
 import * as React from "react";
 
 import {
+  ADVANCED_SETTINGS_STORAGE_KEY,
   AdvancedSettingsSchema,
   DEFAULT_ADVANCED_SETTINGS,
+  migrateLegacyAdvancedSettings,
 } from "@/lib/advanced-settings";
 import { useLocalStorage } from "@/lib/use-local-storage";
 
@@ -26,12 +28,19 @@ export function AdvancedSettingsProvider({
 }: AdvancedSettingsProviderProps) {
   const [settings, setSettings] = useLocalStorage<AdvancedSettings>(
     DEFAULT_ADVANCED_SETTINGS,
-    "poe-udt:trade-settings:v1",
+    ADVANCED_SETTINGS_STORAGE_KEY,
     {
       debounceDelay: 300,
       schema: AdvancedSettingsSchema,
     },
   );
+
+  React.useEffect(() => {
+    const migrated = migrateLegacyAdvancedSettings();
+    if (migrated !== null) {
+      setSettings(migrated);
+    }
+  }, [setSettings]);
 
   const value = React.useMemo(
     () => ({ settings, setSettings }),

--- a/src/lib/advanced-settings.ts
+++ b/src/lib/advanced-settings.ts
@@ -11,13 +11,62 @@ export const AdvancedSettingsSchema = z.object({
     .int()
     .min(MIN_ITEM_LEVEL_RANGE.min)
     .max(MIN_ITEM_LEVEL_RANGE.max)
-    .prefault(78),
+    .prefault(MIN_ITEM_LEVEL_RANGE.max),
   includeCorrupted: z.boolean().prefault(true),
   listingTimeFilter: ListingTimeFilterSchema.prefault("3days"),
   onlineStatus: OnlineStatusSchema.prefault("available"),
 });
 
 export type AdvancedSettings = z.infer<typeof AdvancedSettingsSchema>;
+
+export const ADVANCED_SETTINGS_STORAGE_KEY = "poe-udt:trade-settings:v2";
+export const LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1 =
+  "poe-udt:trade-settings:v1";
+export const LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1 = 78;
+
+/**
+ * One-time migration from the v1 storage key to the v2 storage key.
+ *
+ * Copies every setting over 1:1, except minItemLevel: the legacy default (78)
+ * becomes the new default (highest item level), while custom values are kept
+ * as-is. The legacy key is removed after migrating. Returns the migrated
+ * settings so the caller can adopt them as the current state, or null when
+ * there was nothing to migrate.
+ */
+export function migrateLegacyAdvancedSettings(): AdvancedSettings | null {
+  const legacyRaw = window.localStorage.getItem(
+    LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+  );
+  if (legacyRaw === null) return null;
+
+  if (window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY) !== null) {
+    window.localStorage.removeItem(LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1);
+    return null;
+  }
+
+  let migrated: AdvancedSettings | null = null;
+  try {
+    const legacy = AdvancedSettingsSchema.safeParse(JSON.parse(legacyRaw));
+    if (legacy.success) {
+      migrated = {
+        ...legacy.data,
+        minItemLevel:
+          legacy.data.minItemLevel === LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1
+            ? MIN_ITEM_LEVEL_RANGE.max
+            : legacy.data.minItemLevel,
+      };
+      window.localStorage.setItem(
+        ADVANCED_SETTINGS_STORAGE_KEY,
+        JSON.stringify(migrated),
+      );
+    }
+  } catch {
+    // Invalid legacy data; fall through to cleanup
+  } finally {
+    window.localStorage.removeItem(LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1);
+  }
+  return migrated;
+}
 
 const ADVANCED_SETTINGS_KEYS = Object.keys(
   AdvancedSettingsSchema.shape,

--- a/src/lib/advanced-settings.ts
+++ b/src/lib/advanced-settings.ts
@@ -29,9 +29,11 @@ export const LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1 = 78;
  *
  * Copies every setting over 1:1, except minItemLevel: the legacy default (78)
  * becomes the new default (highest item level), while custom values are kept
- * as-is. The legacy key is removed after migrating. Returns the migrated
- * settings so the caller can adopt them as the current state, or null when
- * there was nothing to migrate.
+ * as-is. Legacy data always wins: even when v2 data already exists (e.g.,
+ * after a rollback to an older version), the legacy values are migrated over
+ * it. The legacy key is removed no matter whether the data was valid. Returns
+ * the migrated settings so the caller can adopt them as the current state, or
+ * null when there was nothing to migrate.
  */
 export function migrateLegacyAdvancedSettings(): AdvancedSettings | null {
   const legacyRaw = window.localStorage.getItem(
@@ -39,33 +41,27 @@ export function migrateLegacyAdvancedSettings(): AdvancedSettings | null {
   );
   if (legacyRaw === null) return null;
 
-  if (window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY) !== null) {
-    window.localStorage.removeItem(LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1);
-    return null;
-  }
+  window.localStorage.removeItem(LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1);
 
-  let migrated: AdvancedSettings | null = null;
   try {
     const legacy = AdvancedSettingsSchema.safeParse(JSON.parse(legacyRaw));
-    if (legacy.success) {
-      migrated = {
-        ...legacy.data,
-        minItemLevel:
-          legacy.data.minItemLevel === LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1
-            ? MIN_ITEM_LEVEL_RANGE.max
-            : legacy.data.minItemLevel,
-      };
-      window.localStorage.setItem(
-        ADVANCED_SETTINGS_STORAGE_KEY,
-        JSON.stringify(migrated),
-      );
-    }
+    if (!legacy.success) return null;
+
+    const migrated: AdvancedSettings = {
+      ...legacy.data,
+      minItemLevel:
+        legacy.data.minItemLevel === LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1
+          ? MIN_ITEM_LEVEL_RANGE.max
+          : legacy.data.minItemLevel,
+    };
+    window.localStorage.setItem(
+      ADVANCED_SETTINGS_STORAGE_KEY,
+      JSON.stringify(migrated),
+    );
+    return migrated;
   } catch {
-    // Invalid legacy data; fall through to cleanup
-  } finally {
-    window.localStorage.removeItem(LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1);
+    return null;
   }
-  return migrated;
 }
 
 const ADVANCED_SETTINGS_KEYS = Object.keys(

--- a/src/lib/advanced-settings.ts
+++ b/src/lib/advanced-settings.ts
@@ -31,7 +31,8 @@ export const LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1 = 78;
  * becomes the new default (highest item level), while custom values are kept
  * as-is. Legacy data always wins: even when v2 data already exists (e.g.,
  * after a rollback to an older version), the legacy values are migrated over
- * it. The legacy key is removed no matter whether the data was valid. Returns
+ * it. The legacy key is removed up front: if the v2 write then fails (e.g.,
+ * storage quota exceeded), the v1 data is lost — this is accepted. Returns
  * the migrated settings so the caller can adopt them as the current state, or
  * null when there was nothing to migrate.
  */

--- a/src/lib/dust/calculation.ts
+++ b/src/lib/dust/calculation.ts
@@ -91,7 +91,6 @@ export const calculateDustValueFull = (
   return finalDust;
 };
 
-
 /**
  * Reverse-calculates the range of base dust values that could produce a given
  * final Thaumaturgic Dust value after rounding.
@@ -122,16 +121,11 @@ export const calculateBaseDustRange = (
   const clampedIlvl = Math.min(Math.max(ilvl, 65), 84);
 
   const increaseByFactors =
-    quality * 2 +
-    influenceCount * 50 +
-    corruptionImplicitCount * 50;
+    quality * 2 + influenceCount * 50 + corruptionImplicitCount * 50;
 
   const factorsMultiplier = (increaseByFactors + 100) / 100;
 
-  const globalMultiplier =
-    125 *
-    (20 - (84 - clampedIlvl)) *
-    factorsMultiplier;
+  const globalMultiplier = 125 * (20 - (84 - clampedIlvl)) * factorsMultiplier;
 
   return {
     minBaseDust: (finalDust - 0.5) / globalMultiplier,

--- a/src/tests/e2e/poe-page.ts
+++ b/src/tests/e2e/poe-page.ts
@@ -1540,4 +1540,25 @@ export class PoEDisenchantPage {
     await this.verifyOnlineStatusFilter(DEFAULT_ADVANCED_SETTINGS.onlineStatus);
     await this.verifyResetButtonDisabled(true);
   }
+
+  // localStorage
+  async expectStorageKey(key: string, expected: string | null): Promise<void> {
+    const stored = await this.page.evaluate(
+      (k) => localStorage.getItem(k),
+      key,
+    );
+    expect(stored).toBe(expected);
+  }
+
+  async expectStorageKeyContains(
+    key: string,
+    expected: Record<string, unknown>,
+  ): Promise<void> {
+    const stored = await this.page.evaluate(
+      (k) => localStorage.getItem(k),
+      key,
+    );
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toMatchObject(expected);
+  }
 }

--- a/src/tests/e2e/tests/desktop/advanced-settings-panel.spec.ts
+++ b/src/tests/e2e/tests/desktop/advanced-settings-panel.spec.ts
@@ -1,4 +1,9 @@
-import { DEFAULT_ADVANCED_SETTINGS } from "@/lib/advanced-settings";
+import {
+  ADVANCED_SETTINGS_STORAGE_KEY,
+  DEFAULT_ADVANCED_SETTINGS,
+  LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+  LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1,
+} from "@/lib/advanced-settings";
 import {
   LISTING_TIME_LABELS,
   ListingTimeFilterSchema,
@@ -454,9 +459,9 @@ test.describe("Settings Persistence", () => {
     const newPoePage = new PoEDisenchantPage(newPage);
 
     // Set invalid localStorage data
-    await newPage.addInitScript(() => {
-      localStorage.setItem("poe-udt:trade-settings:v1", "invalid-json");
-    });
+    await newPage.addInitScript((key) => {
+      localStorage.setItem(key, "invalid-json");
+    }, ADVANCED_SETTINGS_STORAGE_KEY);
     await newPoePage.setup();
 
     // Should load with default settings
@@ -475,12 +480,9 @@ test.describe("Settings Persistence", () => {
     const newPoePage = new PoEDisenchantPage(newPage);
 
     // Set partial localStorage data (missing some fields)
-    await newPage.addInitScript(() => {
-      localStorage.setItem(
-        "poe-udt:trade-settings:v1",
-        JSON.stringify({ minItemLevel: 70 }),
-      );
-    });
+    await newPage.addInitScript((key) => {
+      localStorage.setItem(key, JSON.stringify({ minItemLevel: 70 }));
+    }, ADVANCED_SETTINGS_STORAGE_KEY);
     await newPoePage.setup();
 
     // Should load with defaults for missing fields
@@ -490,6 +492,85 @@ test.describe("Settings Persistence", () => {
     await newPoePage.verifyIncludeCorrupted(
       DEFAULT_ADVANCED_SETTINGS.includeCorrupted,
     );
+  });
+
+  test("should migrate legacy v1 settings on load", async ({ context }) => {
+    // Open page manually
+    const newPage = await context.newPage();
+    const newPoePage = new PoEDisenchantPage(newPage);
+
+    // Set legacy settings (minItemLevel at the old default) alongside custom values
+    await newPage.addInitScript(
+      ({ key, data }) => {
+        localStorage.setItem(key, JSON.stringify(data));
+      },
+      {
+        key: LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+        data: {
+          minItemLevel: LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1,
+          includeCorrupted: false,
+          listingTimeFilter: "1day",
+          onlineStatus: "available",
+        },
+      },
+    );
+    await newPoePage.setup();
+
+    // The legacy default should be migrated to the new default (highest item level),
+    // other settings should be transferred 1:1, and the legacy key should be removed
+    await newPoePage.openAdvancedSettings();
+    await newPoePage.verifyMinItemLevel(DEFAULT_ADVANCED_SETTINGS.minItemLevel);
+    await newPoePage.verifyIncludeCorrupted(false);
+    await newPoePage.verifyListingTimeFilter("1day");
+    await newPoePage.expectStorageKey(
+      LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+      null,
+    );
+    await newPoePage.expectStorageKeyContains(ADVANCED_SETTINGS_STORAGE_KEY, {
+      minItemLevel: DEFAULT_ADVANCED_SETTINGS.minItemLevel,
+      includeCorrupted: false,
+      listingTimeFilter: "1day",
+      onlineStatus: "available",
+    });
+  });
+
+  test("should migrate legacy v1 settings 1:1 when minItemLevel is custom", async ({
+    context,
+  }) => {
+    // Open page manually
+    const newPage = await context.newPage();
+    const newPoePage = new PoEDisenchantPage(newPage);
+
+    // Set legacy settings with a custom minItemLevel
+    await newPage.addInitScript(
+      ({ key, data }) => {
+        localStorage.setItem(key, JSON.stringify(data));
+      },
+      {
+        key: LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+        data: {
+          minItemLevel: 70,
+          includeCorrupted: false,
+          listingTimeFilter: "1day",
+        },
+      },
+    );
+    await newPoePage.setup();
+
+    // The custom value should be transferred 1:1, and the legacy key should be removed
+    await newPoePage.openAdvancedSettings();
+    await newPoePage.verifyMinItemLevel(70);
+    await newPoePage.verifyIncludeCorrupted(false);
+    await newPoePage.verifyListingTimeFilter("1day");
+    await newPoePage.expectStorageKey(
+      LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+      null,
+    );
+    await newPoePage.expectStorageKeyContains(ADVANCED_SETTINGS_STORAGE_KEY, {
+      minItemLevel: 70,
+      includeCorrupted: false,
+      listingTimeFilter: "1day",
+    });
   });
 
   test("should persist settings after force closing and reopening page", async ({
@@ -541,18 +622,16 @@ test.describe("Keyboard Navigation", () => {
   }) => {
     await poePage.openAdvancedSettings();
 
+    // Set a value below the max so the slider can be increased
+    await poePage.setMinItemLevel(80);
+
     // Focus slider
     const slider = poePage.minItemLevelSlider;
     await slider.focus();
 
-    // Get initial value
-    const initialValue = await poePage.getMinItemLevel();
-
     // Press right arrow to increase
     await poePage.page.keyboard.press("ArrowRight");
-    await expect(poePage.minItemLevelValue).toHaveText(
-      (initialValue + 1).toString(),
-    );
+    await expect(poePage.minItemLevelValue).toHaveText("81");
   });
 
   test("should toggle include corrupted checkbox with space key", async ({

--- a/src/tests/e2e/tests/desktop/user-interactions.spec.ts
+++ b/src/tests/e2e/tests/desktop/user-interactions.spec.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ADVANCED_SETTINGS } from "@/lib/advanced-settings";
 import { DEFAULT_LEAGUE, getLeagueApiName } from "@/lib/leagues";
 import { expect, test } from "../../fixtures";
 
@@ -134,7 +135,9 @@ test.describe("Trade Link Functionality", () => {
     expect(payload.query.filters.trade_filters.filters.indexed.option).toBe(
       "3days",
     );
-    expect(payload.query.filters.misc_filters.filters.ilvl.min).toBe(78);
+    expect(payload.query.filters.misc_filters.filters.ilvl.min).toBe(
+      DEFAULT_ADVANCED_SETTINGS.minItemLevel,
+    );
     expect(payload.sort.price).toBe("asc");
   });
 });

--- a/src/tests/unit/advanced-settings.test.ts
+++ b/src/tests/unit/advanced-settings.test.ts
@@ -4,11 +4,11 @@ import {
   ADVANCED_SETTINGS_STORAGE_KEY,
   AdvancedSettingsSchema,
   DEFAULT_ADVANCED_SETTINGS,
+  LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+  LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1,
   migrateLegacyAdvancedSettings,
 } from "@/lib/advanced-settings";
 import { MIN_ITEM_LEVEL_RANGE } from "@/lib/filters";
-
-const LEGACY_STORAGE_KEY = "poe-udt:trade-settings:v1";
 
 class MemoryStorage implements Storage {
   private store = new Map<string, string>();
@@ -69,8 +69,8 @@ describe("migrateLegacyAdvancedSettings", () => {
 
   it("migrates the legacy default minItemLevel to the highest item level", () => {
     window.localStorage.setItem(
-      LEGACY_STORAGE_KEY,
-      JSON.stringify({ minItemLevel: 78 }),
+      LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+      JSON.stringify({ minItemLevel: LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1 }),
     );
 
     const migrated = migrateLegacyAdvancedSettings();
@@ -81,7 +81,9 @@ describe("migrateLegacyAdvancedSettings", () => {
       JSON.parse(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)!)
         .minItemLevel,
     ).toBe(MIN_ITEM_LEVEL_RANGE.max);
-    expect(window.localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+    expect(
+      window.localStorage.getItem(LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1),
+    ).toBeNull();
   });
 
   it("transfers custom minItemLevel values 1:1", () => {
@@ -94,7 +96,7 @@ describe("migrateLegacyAdvancedSettings", () => {
     ]) {
       window.localStorage.clear();
       window.localStorage.setItem(
-        LEGACY_STORAGE_KEY,
+        LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
         JSON.stringify({ minItemLevel }),
       );
 
@@ -110,9 +112,9 @@ describe("migrateLegacyAdvancedSettings", () => {
 
   it("transfers all other settings 1:1", () => {
     window.localStorage.setItem(
-      LEGACY_STORAGE_KEY,
+      LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
       JSON.stringify({
-        minItemLevel: 78,
+        minItemLevel: LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1,
         includeCorrupted: false,
         listingTimeFilter: "1day",
         onlineStatus: "securable",
@@ -130,30 +132,39 @@ describe("migrateLegacyAdvancedSettings", () => {
   });
 
   it("removes the legacy key and returns null when its data is invalid", () => {
-    window.localStorage.setItem(LEGACY_STORAGE_KEY, "invalid-json");
+    window.localStorage.setItem(
+      LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+      "invalid-json",
+    );
 
     expect(migrateLegacyAdvancedSettings()).toBeNull();
-    expect(window.localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+    expect(
+      window.localStorage.getItem(LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1),
+    ).toBeNull();
     expect(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)).toBe(
       null,
     );
   });
 
-  it("does not overwrite existing v2 data", () => {
+  it("migrates legacy v1 data over existing v2 data", () => {
     window.localStorage.setItem(
       ADVANCED_SETTINGS_STORAGE_KEY,
       JSON.stringify({ minItemLevel: 65 }),
     );
     window.localStorage.setItem(
-      LEGACY_STORAGE_KEY,
-      JSON.stringify({ minItemLevel: 78 }),
+      LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1,
+      JSON.stringify({ minItemLevel: LEGACY_MIN_ITEM_LEVEL_DEFAULT_V1 }),
     );
 
-    expect(migrateLegacyAdvancedSettings()).toBeNull();
+    const migrated = migrateLegacyAdvancedSettings();
+
+    expect(migrated!.minItemLevel).toBe(MIN_ITEM_LEVEL_RANGE.max);
     expect(
       JSON.parse(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)!)
         .minItemLevel,
-    ).toBe(65);
-    expect(window.localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+    ).toBe(MIN_ITEM_LEVEL_RANGE.max);
+    expect(
+      window.localStorage.getItem(LEGACY_ADVANCED_SETTINGS_STORAGE_KEY_V1),
+    ).toBeNull();
   });
 });

--- a/src/tests/unit/advanced-settings.test.ts
+++ b/src/tests/unit/advanced-settings.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ADVANCED_SETTINGS_STORAGE_KEY,
+  AdvancedSettingsSchema,
+  DEFAULT_ADVANCED_SETTINGS,
+  migrateLegacyAdvancedSettings,
+} from "@/lib/advanced-settings";
+import { MIN_ITEM_LEVEL_RANGE } from "@/lib/filters";
+
+const LEGACY_STORAGE_KEY = "poe-udt:trade-settings:v1";
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("window", { localStorage: new MemoryStorage() });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DEFAULT_ADVANCED_SETTINGS", () => {
+  it("uses the highest item level as default minItemLevel", () => {
+    expect(DEFAULT_ADVANCED_SETTINGS.minItemLevel).toBe(
+      MIN_ITEM_LEVEL_RANGE.max,
+    );
+  });
+
+  it("fills missing minItemLevel with the highest item level", () => {
+    const parsed = AdvancedSettingsSchema.parse({ includeCorrupted: false });
+    expect(parsed.minItemLevel).toBe(MIN_ITEM_LEVEL_RANGE.max);
+  });
+});
+
+describe("migrateLegacyAdvancedSettings", () => {
+  it("returns null when there is no legacy key", () => {
+    expect(migrateLegacyAdvancedSettings()).toBeNull();
+    expect(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)).toBe(
+      null,
+    );
+  });
+
+  it("migrates the legacy default minItemLevel to the highest item level", () => {
+    window.localStorage.setItem(
+      LEGACY_STORAGE_KEY,
+      JSON.stringify({ minItemLevel: 78 }),
+    );
+
+    const migrated = migrateLegacyAdvancedSettings();
+
+    expect(migrated).not.toBeNull();
+    expect(migrated!.minItemLevel).toBe(MIN_ITEM_LEVEL_RANGE.max);
+    expect(
+      JSON.parse(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)!)
+        .minItemLevel,
+    ).toBe(MIN_ITEM_LEVEL_RANGE.max);
+    expect(window.localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+  });
+
+  it("transfers custom minItemLevel values 1:1", () => {
+    for (const minItemLevel of [
+      MIN_ITEM_LEVEL_RANGE.min,
+      70,
+      80,
+      83,
+      MIN_ITEM_LEVEL_RANGE.max,
+    ]) {
+      window.localStorage.clear();
+      window.localStorage.setItem(
+        LEGACY_STORAGE_KEY,
+        JSON.stringify({ minItemLevel }),
+      );
+
+      const migrated = migrateLegacyAdvancedSettings();
+
+      expect(migrated!.minItemLevel).toBe(minItemLevel);
+      expect(
+        JSON.parse(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)!)
+          .minItemLevel,
+      ).toBe(minItemLevel);
+    }
+  });
+
+  it("transfers all other settings 1:1", () => {
+    window.localStorage.setItem(
+      LEGACY_STORAGE_KEY,
+      JSON.stringify({
+        minItemLevel: 78,
+        includeCorrupted: false,
+        listingTimeFilter: "1day",
+        onlineStatus: "securable",
+      }),
+    );
+
+    const migrated = migrateLegacyAdvancedSettings();
+
+    expect(migrated).toEqual({
+      minItemLevel: MIN_ITEM_LEVEL_RANGE.max,
+      includeCorrupted: false,
+      listingTimeFilter: "1day",
+      onlineStatus: "securable",
+    });
+  });
+
+  it("removes the legacy key and returns null when its data is invalid", () => {
+    window.localStorage.setItem(LEGACY_STORAGE_KEY, "invalid-json");
+
+    expect(migrateLegacyAdvancedSettings()).toBeNull();
+    expect(window.localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)).toBe(
+      null,
+    );
+  });
+
+  it("does not overwrite existing v2 data", () => {
+    window.localStorage.setItem(
+      ADVANCED_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ minItemLevel: 65 }),
+    );
+    window.localStorage.setItem(
+      LEGACY_STORAGE_KEY,
+      JSON.stringify({ minItemLevel: 78 }),
+    );
+
+    expect(migrateLegacyAdvancedSettings()).toBeNull();
+    expect(
+      JSON.parse(window.localStorage.getItem(ADVANCED_SETTINGS_STORAGE_KEY)!)
+        .minItemLevel,
+    ).toBe(65);
+    expect(window.localStorage.getItem(LEGACY_STORAGE_KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved advanced settings storage migration for existing configurations.
  * Preserved custom minimum item levels during migration.
  * Prevented existing current-format settings from being overwritten.
  * Updated the default minimum item level to match the maximum configured level.

* **Tests**
  * Added coverage for legacy settings migration, invalid data, defaults, and configuration preservation.
  * Improved end-to-end validation of stored settings and keyboard slider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->